### PR TITLE
ipa-keycloak: add demo for external IDP using Keycloak

### DIFF
--- a/ipalab-config/ipa-keycloak/README.md
+++ b/ipalab-config/ipa-keycloak/README.md
@@ -1,0 +1,191 @@
+# FreeIPA external IDP integration with Keycloak
+
+In this example an environment with a [FreeIPA](https://freeipa.org)
+and a [Keycloak](https://keycloak.org) servers is created so that user
+authentication in IPA, using an external IDP is performed.
+
+## Preparing the environment
+
+Create the configuration:
+
+```
+python3 -m venv /tmp/ipalab
+. /tmp/ipalab/bin/activate
+pip install -r requirements.txt
+```
+
+Build the container image and instantiate containers:
+
+```
+ipalab-config lab_ipa_keycloak.yml
+cd ipa-keycloak-idp
+podman-compose build
+podman-compose up -d
+```
+
+At this point, you'll have two containers, one based on the oficial
+Keycloak container image, and one that can have IPA deployed to.
+
+Deploy the IPA cluster using
+[ansible-freeipa](https://gtihub.com/freeipa/ansible-freeipa):
+
+```
+ansible-galaxy collection install \
+    freeipa.ansible_freeipa \
+    containers.podman
+ansible-playbook -i inventory.yml \
+    ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
+```
+
+The provided Keycloak container uses a self-signed certificate that is
+unkown to the IPA container. The certificate is found in the container
+`keycloak` at the path `/opt/keycloak/conf/cert.pem`. This certificate
+must be added to the list of trusted certificates on the `server`
+container. This can be achieved by executing:
+
+```
+keycloak/trust_keycloak.sh server
+```
+
+## Using Keycloak web interface
+
+Since the whole environment runs using rootles containers, in a Podman
+virtual network, direct access to the host ports is not possible, but
+can be achieved using `podman unshare`. For example, to _ssh_ into the
+container (if `sshd` is available) or to access the `httpd` server.
+
+When using [Firefox](https://mozilla.org/firefox) a profile is needed
+to access the containers URLs, and to ease access the script
+`scripts/open-firefox.sh` is provided. This script will manage the
+Firefox profile and call `firefox` with the proper configuration for
+`podman unshare`, allowing access to Keycloak and WebUI.
+
+Before starting Firefox, add the entries found in the generated `hosts`
+file to your machine `/etc/hosts` so the host names can be resolved. The
+file `hosts` has all the containers entries needed, add it with:
+
+```
+sudo bash -c "cat hosts >> /etc/hosts"
+```
+
+Start the Keycloak web interface with:
+
+```
+scripts/open-firefox.sh https://keycloak.example.test:8443
+```
+
+In a similar fashion you can access the IPA WebUI with:
+
+```
+scripts/open-firefox.sh https://server.ipa.test:443
+```
+
+
+## Setting up Keycloak as an External IDP for IPA
+
+In order to perform OAuth 2.0 device authorization grant flow against
+an IdP, an OAuth 2.0 client has to be registered with the IdP and a
+capability to allow the device authorization grant has to be given to it.
+
+On Keycloak, this is achieved by setting _OAuth 2.0 Device Authorization Grant_,
+in the _Authentication Flow_, to `true`.
+
+The configuration required for the Keycloak client is:
+
+```json
+{
+  "enabled" : true,
+  "clientAuthenticatorType" : "client-secret",
+  "redirectUris" : [ "https://${IPASERVER}/ipa/idp/*" ],
+  "webOrigins" : [ "https://${IPASERVER}" ],
+  "protocol" : "openid-connect",
+  "attributes" : {
+    "oauth2.device.authorization.grant.enabled" : "true",
+    "oauth2.device.polling.interval": "5"
+  }
+}
+```
+
+Note that `oauth2.device.authorization.grant.enabled` is enabled.
+
+To create the OIDC client for Keycloak, you can use the script provided
+by `ipalab-config`. The script requires the IPA FQDN, an OIDC client ID
+and the OIDC client password. Execute:
+
+```
+keycloak/keycloak_add_oidc_client.sh \
+    server.ipa.test \
+    ipa_oidc_client \
+    Secret123
+```
+
+Now, we can set the external IDP on IPA, either by using the `idp-add`
+CLI command, or with a playbook, using ansible-freeipa:
+
+```
+ansible-playbook -i inventory.yml playbooks/idp_keycloak.yml
+```
+
+## Testing the setup
+
+To test the setup, create a user on Keycloak using:
+
+```
+keycloak/keycloak_add_user.sh jdoe jdoe@example.test userPASS
+```
+
+Perform login with user `jdoe` on Keycloak web interface:
+
+```
+scripts/open-firefox.sh https://keycloak.example.test:8443/realms/master/account
+```
+
+And add a user on IPA, with authorization through IDP:
+
+```
+ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml
+```
+
+Now to authorize the new user, the commands should be execute on the
+`server` container:
+
+```
+podman exec -it server bash
+```
+
+On the `server`, execute:
+
+```
+[server]$ kinit -n -c ./fast.ccache
+[server]$ kinit -T ./fast.ccache jdoe
+Authenticate at https://keycloak.example.test:8443/realms/master/device?user_code=GKTH-BJSS and press ENTER.:
+```
+
+Copy the provided link to the same Firefox window as `jdoe` has logged in, and grant the required authorization.
+
+When back to the console, type ENTER, and if everything went fine, user will have a TGT for `jdoe` on IPA side:
+
+```
+[server]$ klist -A
+Ticket cache: FILE:/tmp/krb5cc_0
+Default principal: jdoe@IPA.TEST
+
+Valid starting     Expires            Service principal
+05/09/25 16:34:00  05/10/25 16:18:52  krbtgt/IPA.TEST@IPA.TEST
+```
+
+## Troubleshooting
+
+If anything goes wrong, you can search `journalctl` for `ipa-otpd`
+entries.
+
+To increase the log level, set the `oidc_child` debug level in
+`/etc/ipa/default.conf` by setting:
+
+```
+[global]
+oidc_child_debug_level=10
+```
+
+Valid values are between 0 and 10 and any value above 6 includes debug
+output from `libcurl` utility.

--- a/ipalab-config/ipa-keycloak/ipa-keycloak-idp.tape
+++ b/ipalab-config/ipa-keycloak/ipa-keycloak-idp.tape
@@ -1,0 +1,152 @@
+Output out.webm
+Set FontSize 16
+Set Width 1200
+Set Height 800
+Require python3
+Require podman
+Sleep 2s
+Hide
+Type "export PS1='[\W]$ '"
+Enter
+Wait /.*[\$#] *$/
+Type "command -v deactivate && deactivate"
+Enter
+Wait /.*[\$#] *$/
+Type "rm -rf /tmp/ipalab-ipa-keycloak"
+Enter
+Wait /.*[\$#] *$/
+Ctrl+L
+Show
+Type "`# Install support software`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "python3 -m venv /tmp/ipalab-ipa-keycloak"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type ". /tmp/ipalab-ipa-keycloak/bin/activate"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "pip install -r requirements.txt"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Create and activate the configuration`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ipalab-config lab_ipa_keycloak.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "cd ipa-keycloak-idp"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman-compose build"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman-compose up -d"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Trust Keycloak self-signed certificate`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/trust_keycloak.sh server"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Install containers.podman collection`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-galaxy collection install containers.podman"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Install freeipa.ansible_freeipa collection`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-galaxy collection install freeipa.ansible_freeipa"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Video cut to deploy IPA cluster`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "`# ansible-playbook -i inventory.yml ${ansible_freeipa_collection_path}install-cluster.yml`"
+Sleep 500ms
+Enter
+Sleep 5s
+Hide
+Type "ansible-playbook -i inventory.yml ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml"
+Enter
+Wait@10m  /.*[\$#] *$/
+Show
+Type "`# Create Keycloak OIDC client`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/keycloak_add_oidc_client.sh  server.ipa.test ipa_oidc_client Secret123"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Configure IDP endpoint in IPA`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-playbook -i inventory.yml playbooks/idp_keycloak.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Test IDP connection with user 'jdoe'`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "`# Create user on Keycloak`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/keycloak_add_user.sh jdoe jdoe@example.test userPASS"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Add user to IPA`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 5s
+Ctrl+L
+Type "`# kinit user jdoe on IPA server`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "podman exec server kinit -n -c /fast.ccache"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman exec server kinit -T /fast.ccache jdoe"
+Sleep 500ms
+Enter
+Wait@5s  /.*[\$#] *$/
+Type "`# Some issues may be present in this demo, and for a complete execution, access to a browser is needed.`"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/ipalab-config/ipa-keycloak/lab_ipa_keycloak.yml
+++ b/ipalab-config/ipa-keycloak/lab_ipa_keycloak.yml
@@ -1,0 +1,23 @@
+---
+lab_name: ipa-keycloak-idp
+subnet: "192.168.14.0/24"
+extra_data:
+  - playbooks
+  - scripts
+external:
+  hosts:
+  - name: keycloak
+    hostname: keycloak.example.test
+    role: keycloak
+    options:
+      admin_username: admin
+      admin_password: Secret123
+ipa_deployments:
+  - name: ipa
+    domain: ipa.test
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          # capabilities: ["DNS"]

--- a/ipalab-config/ipa-keycloak/playbooks/add_user_auth_idp.yml
+++ b/ipalab-config/ipa-keycloak/playbooks/add_user_auth_idp.yml
@@ -1,0 +1,23 @@
+---
+- name: Add IPA user using IDP authorization
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  collections:
+    - freeipa.ansible_freeipa
+
+  module_defaults:
+    group/freeipa.ansible_freeipa.modules:
+      ipaadmin_password: SomeADMINpassword
+
+  tasks:
+  - name: Ensure user 'jdoe' exists and uses 'idp' for authorization
+    ipauser:
+      name: jdoe
+      first: John
+      last: doe
+      email: jdoe@ipa.test
+      idp: keycloak-idp
+      idp_user_id: jdoe@example.test
+      userauthtype: idp

--- a/ipalab-config/ipa-keycloak/playbooks/idp_keycloak.yml
+++ b/ipalab-config/ipa-keycloak/playbooks/idp_keycloak.yml
@@ -1,0 +1,22 @@
+---
+- name: Add Keycloak as an external IDP for IPA
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  collections:
+    - freeipa.ansible_freeipa
+
+  module_defaults:
+    group/freeipa.ansible_freeipa.modules:
+      ipaadmin_password: SomeADMINpassword
+
+  tasks:
+  - name: Ensure Keycloak IDP is present
+    ipaidp:
+      name: keycloak-idp
+      provider: keycloak
+      organization: master
+      base_url: "https://keycloak.example.test:8443"
+      client_id: ipa_oidc_client
+      secret: Secret123

--- a/ipalab-config/ipa-keycloak/requirements.txt
+++ b/ipalab-config/ipa-keycloak/requirements.txt
@@ -1,0 +1,2 @@
+ipalab-config>=0.13
+ansible-core

--- a/ipalab-config/ipa-keycloak/scripts/open-firefox.sh
+++ b/ipalab-config/ipa-keycloak/scripts/open-firefox.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+die() {
+    >&2 echo $*
+    exit 1
+}
+
+detach() {
+    nohup "$@" >/dev/null 2>&1 </dev/null &
+}
+
+usage() {
+    cat <<EOF
+usage: $(basename "$0") [-p PROFILE] [-r] [URL]"
+
+Open URL in Firefox with the given profile.
+
+Options:
+
+    -p PROFILE   use the given profile name
+    -r           remove the profile
+
+EOF
+}
+
+
+MOZILLA_PROFILES="${HOME}/.mozilla/firefox/profiles.ini"
+
+profile_name="ipalab-profile"
+cmd="open"
+
+while getopts ":hp:r" option
+do
+    case "${option}" in
+        h) usage && exit 0 ;;
+        p) profile_name="${OPTARG}" ;;
+        r) cmd="remove" ;;
+        *) die -u "Invalid option: ${OPTARG}" ;;
+    esac
+done
+shift "$((OPTIND - 1))"
+
+[ $# -gt 1 ] && die "Only one URL can be used. (Didn't you forgot '-p'?)"
+
+echo "Using profile ${profile_name}"
+
+WORKSHOP_PROFILE_DIR="${HOME}/.mozilla/firefox/${profile_name}"
+
+if [ "$cmd" == "remove" ]
+then
+    sed -i "/^\# start - Added by ipalab-config: ${profile_name}$/,/^\# end - Added by ipalab-config: ${profile_name}/d" "${MOZILLA_PROFILES}"
+    rm -rf "${WORKSHOP_PROFILE_DIR}"
+    exit
+fi
+
+if [ ! -d "${WORKSHOP_PROFILE_DIR}" ]
+then
+    mkdir "${WORKSHOP_PROFILE_DIR}"
+    certutil -N -d "${WORKSHOP_PROFILE_DIR}"
+    podman cp server:/etc/ipa/ca.crt "${WORKSHOP_PROFILE_DIR}/ca.crt"
+    certutil -A -i "${WORKSHOP_PROFILE_DIR}/ca.crt" -d "${WORKSHOP_PROFILE_DIR}" -n "Certificate Authority - IPA dev ${profile_name}" -t "CT,C,"
+fi
+
+if ! grep -q "Name=${profile_name}" "${MOZILLA_PROFILES}"
+then
+    echo "Creating Firefox profile: ${profile_name}"
+
+    next_profile=$(echo $(($(cat "${MOZILLA_PROFILES}" | sed -n 's/\[Profile\([^\]]*\)\]/\1/p' | sort -n | tail -n 1) + 1)))
+
+    cat >> "${MOZILLA_PROFILES}" <<EOF
+# start - Added by ipa-demos: ${profile_name}
+[Profile${next_profile}]
+Name=${profile_name}
+IsRelative=1
+Path=${profile_name}
+# end - Added by ipa-demos
+EOF
+
+fi
+
+[ -z "$@" ] || detach podman unshare --rootless-netns firefox -P "$profile_name" --new-window "$@"

--- a/ipalab-config/ipa-keycloak/vcr_demo.sh
+++ b/ipalab-config/ipa-keycloak/vcr_demo.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+
+# vcr: -- This script is used to creath the vhs tape using vcr
+# vcr: -- vcr: https://github.com/rjeffman/vcr
+
+# vcr: hide
+export PS1='[\\W]$ '
+command -v deactivate && deactivate
+rm -rf /tmp/ipalab-ipa-keycloak
+
+# vcr: clear show
+# Install support software
+python3 -m venv /tmp/ipalab-ipa-keycloak
+. /tmp/ipalab-ipa-keycloak/bin/activate
+pip install -r requirements.txt
+
+# vcr: clear
+# Create and activate the configuration
+ipalab-config lab_ipa_keycloak.yml
+cd ipa-keycloak-idp
+podman-compose build
+podman-compose up -d
+
+# Trust Keycloak self-signed certificate
+keycloak/trust_keycloak.sh server
+
+# vcr: clear
+# Install containers.podman collection
+ansible-galaxy collection install containers.podman
+# Install freeipa.ansible_freeipa collection
+ansible-galaxy collection install freeipa.ansible_freeipa
+
+# vcr: clear
+# Video cut to deploy IPA cluster
+# ansible-playbook -i inventory.yml ${ansible_freeipa_collection_path}\install-cluster.yml
+# vcr: -- Hide IPA installation for smaller video.
+# vcr: hide timeout=10m
+ansible-playbook -i inventory.yml ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
+
+# vcr: show
+# Create Keycloak OIDC client
+keycloak/keycloak_add_oidc_client.sh  server.ipa.test ipa_oidc_client Secret123
+
+# Configure IDP endpoint in IPA
+ansible-playbook -i inventory.yml playbooks/idp_keycloak.yml
+
+# Test IDP connection with user 'jdoe'
+
+# Create user on Keycloak
+keycloak/keycloak_add_user.sh jdoe jdoe@example.test userPASS
+
+# Add user to IPA
+ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml
+
+# kinit user jdoe on IPA server
+podman exec server kinit -n -c /fast.ccache
+# vcr: timeout=5s
+podman exec server kinit -T /fast.ccache jdoe
+
+# Some issues may be present in this demo, and for a complete execution, access to a browser is needed.
+


### PR DESCRIPTION
This demo is based on the ipalab-config configuration of Keycloak, which is based on the official Keycloak container image, using a self-signed certificate for HTTPS connection. Keycloak runs in production mode.

Helper scripts and playbooks for configuring Keycloak and IPA are provided.

## Summary by Sourcery

Add a comprehensive demo for integrating FreeIPA with Keycloak as an external Identity Provider (IdP), demonstrating OAuth 2.0 device authorization grant flow and user authentication across the two systems.

New Features:
- Implement a complete demo for external IdP integration between FreeIPA and Keycloak
- Create scripts and playbooks for configuring Keycloak and IPA integration
- Demonstrate OAuth 2.0 device authorization grant flow

Documentation:
- Add detailed README.md with step-by-step configuration and testing instructions
- Include troubleshooting guidelines for IdP integration

Chores:
- Set up configuration files for lab environment
- Create requirements file for dependencies