### PR TITLE
ipa-trust: update to use Fedora 41

### DIFF
--- a/ipalab-config/ipa-trust/containerfile-fedora
+++ b/ipalab-config/ipa-trust/containerfile-fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:40
+FROM registry.fedoraproject.org/fedora-toolbox:41
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 


### PR DESCRIPTION
`freeipa-server-dns` from COPR repository `abbra/wip-ipa-trust` requires version of bind packages available in F41 or later.

If you prefer I can update it to `fedora 42` but I haven't tested this.

## Summary by Sourcery

Enhancements:
- Bump Fedora base image from 38 to 41 in the containerfile